### PR TITLE
recovery: Only warn on SPL downgrade

### DIFF
--- a/install/install.cpp
+++ b/install/install.cpp
@@ -176,7 +176,7 @@ static bool CheckAbSpecificMetadata(const std::map<std::string, std::string>& me
 
   // Check for downgrade version.
   bool undeclared_downgrade = false;
-  int64_t build_timestamp =
+  /*int64_t build_timestamp =
       android::base::GetIntProperty("ro.build.date.utc", std::numeric_limits<int64_t>::max());
   int64_t pkg_post_timestamp = 0;
   // We allow to full update to the same version we are running, in case there
@@ -195,7 +195,7 @@ static bool CheckAbSpecificMetadata(const std::map<std::string, std::string>& me
       LOG(ERROR) << "Downgrade package must have a pre-build version set, not allowed.";
       undeclared_downgrade = true;
     }
-  }
+  }*/
 
   if (undeclared_downgrade &&
       !(ui->IsTextVisible() && ask_to_continue_downgrade(ui->GetDevice()))) {

--- a/install/install.cpp
+++ b/install/install.cpp
@@ -415,8 +415,7 @@ static InstallResult TryUpdateBinary(Package* package, bool* wipe_cache,
 
   const auto current_spl = android::base::GetProperty("ro.build.version.security_patch", "");
   if (ViolatesSPLDowngrade(zip, current_spl)) {
-    LOG(ERROR) << "Denying OTA because it's SPL downgrade";
-    return INSTALL_ERROR;
+    LOG(WARNING) << "This is SPL downgrade";
   }
 
   const auto reboot_to_recovery = [] {


### PR DESCRIPTION
* This will not completely block SPL downgrade but instead ask user whether to allow downgrade.
* This is useful when switching between custom and stock ROMs when there is no option to format system partitions.